### PR TITLE
add retry to task

### DIFF
--- a/lib/kinetik/seed/job.schema.js
+++ b/lib/kinetik/seed/job.schema.js
@@ -37,6 +37,8 @@ module.exports = new Seed.Schema({
 
   , delay: Number
 
+  , retry: Number
+
   , status: {
         type: Type.Select
       , required: true

--- a/lib/kinetik/seed/processor.graph.js
+++ b/lib/kinetik/seed/processor.graph.js
@@ -143,6 +143,9 @@ module.exports = Seed.Graph.extend('processor', {
       var self = this
         , action = task.get('action')
         , timeout = task.get('timeout')
+        , retry = task.get('retry')
+        , maxRetry = task.get('maxRetry')
+        , retryDelay = task.get('retryDelay')
         , hasTimedOut = false
         , timeoutHandle = null
         , param = {};
@@ -226,9 +229,16 @@ module.exports = Seed.Graph.extend('processor', {
         clearTimeout(timeoutHandle);
         if (hasTimedOut) return;
         if (_fail) {
-          var fail = parseFail(_fail);
-          job.set('status', 'failed');
-          job.set('error', fail);
+          var fail = parseFail(_fail)
+            , tryCount = job.get('retry');
+          if (retry && (!maxRetry || tryCount =< maxRetry)) {
+            job.set('status', 'delayed');
+            job.set('retry', tryCount + 1);
+            job.set('delay', new Date().getTime() + retryDelay);
+          } else {
+            job.set('status', 'failed');
+            job.set('error', fail);
+          }
         } else {
           job.set('status', 'completed');
         }

--- a/lib/kinetik/seed/task.model.js
+++ b/lib/kinetik/seed/task.model.js
@@ -223,4 +223,23 @@ module.exports = Seed.Model.extend('task', {
       return this;
     }
 
+    /**
+     * ### .retry
+     *
+     * define if the task should be re-run when it fails
+     *
+     * @param {Number|String} duration between two retries
+     * @param {String} number of retries, infinite if not set
+     * @returns `this` task for chaining
+     * @name retry
+     * @api public
+     */
+
+  , retry: function (retryDelay, maxTries) {
+      this.set('retry', true);
+      this.set('maxTries', maxTries);
+      this.set('retryDelay', _.ms(retryDelay));
+      return this;
+    }
+
 });

--- a/test/fixture/store.js
+++ b/test/fixture/store.js
@@ -228,4 +228,46 @@ module.exports = function (store) {
       });
     });
   });
+
+  it('can retry failed execution', function (done) {
+    var data = { hello: 'universe' }
+      , spy1 = chai.spy(function (job, next) {
+          job.should.not.have.property('_attributes.retry');
+          next('first try is a fail');
+        })
+      , spy2 = chai.spy(function (job, next) {
+          job.should.have.property('_attributes.retry');
+          job._attributes.retry.should.equal(1);
+          process.nextTick(next);
+        })
+      , tries = [spy1, spy2]
+      , spy = chai.spy(function (job, next) {
+          job.should.be.an('object');
+          job.should.have.property('id');
+          job.should.have.property('data')
+            .and.deep.equal(data);
+          tries.length.should.be.gt(0);
+          tries.shift()(job, next);
+        });
+
+    queue
+      .define('task retry')
+      .tag('task rery')
+      .retry('10ms', 1)
+      .on('complete', function (job) {
+        job.get('task').should.equal('task retry');
+        job.get('data').should.deep.equal(data);
+        job.get('status').should.equal('completed');
+        spy.should.have.been.called.twice;
+        spy1.should.have.been.called.once;
+        spy2.should.have.been.called.once;
+        done();
+      })
+      .action(spy);
+
+    queue.create('task retry', data);
+    queue.process([ 'task retry' ]);
+  });
+
+
 };


### PR DESCRIPTION
allow the following when defining a task

``` javascript

    queue
      .define('task retry')
      .tag('task rery')
      .retry('10ms', 5) // retry 5 times with 10ms delay between each try

```

first commit for review I havent tested anything yet
