### PR TITLE
Improve `Task#retry` by supporting `opts`

### DIFF
--- a/lib/kinetik/seed/task.model.js
+++ b/lib/kinetik/seed/task.model.js
@@ -223,7 +223,12 @@ module.exports = Seed.Model.extend('task', {
      *
      * define if the task should be re-run when it fails
      *
-     * @param {Number|String} duration between two retries
+     * Options:
+     *
+     * `retryDelay` duration between two retries
+     * `maxRetry`   number of retries
+     *
+     * @param {Number|String|Object} duration between two retries, when object - options
      * @param {String} number of retries, infinite if not set
      * @returns `this` task for chaining
      * @name retry
@@ -231,6 +236,12 @@ module.exports = Seed.Model.extend('task', {
      */
 
   , retry: function (retryDelay, maxRetry) {
+      if (Object(retryDelay) === retryDelay && arguments.length === 1) {
+        var opts = retryDelay;
+        retryDelay = opts.retryDelay;
+        maxRetry = opts.maxRetry;
+      }
+
       this.set('retry', true);
       this.set('maxRetry', maxRetry);
       this.set('retryDelay', idris.ms(retryDelay));

--- a/test/task.js
+++ b/test/task.js
@@ -46,4 +46,41 @@ describe('task models', function () {
     spy.should.have.been.called.once;
   });
 
+  describe('#retry', function() {
+    describe('retry(retryDelay, maxRetry)', function() {
+      before(function() {
+        task.retry(1, 2);
+      });
+
+      it('sets retry to true', function() {
+        task.get('retry').should.equal(true);
+      });
+
+      it('configures `maxRetry`', function() {
+        task.get('maxRetry').should.equal(2);
+      });
+
+      it('configures `retryDelay`', function() {
+        task.get('retryDelay').should.equal(1);
+      });
+    });
+
+    describe('retry(options)', function() {
+      before(function() {
+        task.retry({ retryDelay: 1, maxRetry: 2 });
+      });
+
+      it('sets retry to true', function() {
+        task.get('retry').should.equal(true);
+      });
+
+      it('configures `maxRetry`', function() {
+        task.get('maxRetry').should.equal(2);
+      });
+
+      it('configures `retryDelay`', function() {
+        task.get('retryDelay').should.equal(1);
+      });
+    });
+  });
 });


### PR DESCRIPTION
The following looks really ambiguous to me. One can easily by mistaken by what 1 is and what 2 is

``` js
task.retry(1, 2);
```

This pull request introduces the ability to supply `opts` WITHOUT introducing API breaking change:

``` js
task.retry({ maxRetry: 3, retryDelay: 4 });
```
